### PR TITLE
Update pt_pt.dart

### DIFF
--- a/lib/translation/pt_pt.dart
+++ b/lib/translation/pt_pt.dart
@@ -13,7 +13,7 @@ class PtPt {
         'month': 'Mês',
         'updateTodo': 'Tarefa atualizada',
         'addTodo': 'Adicionar uma tarefa',
-        'copletedTodo': 'Complete a tarefa',
+        'completedTodo': 'Complete a tarefa',
         'deletedTodo': 'Excluindo uma tarefa',
         'deletedTodoQuery': 'Tem certeza de que deseja excluir a tarefa?',
         'delete': 'Eliminar',


### PR DESCRIPTION
Small fix to turn an already translated entry in this document into a translated entry in the app (the translation of one entry isn't currently displayed in the Zest app due to a typo, with the English version of that entry appearing instead).