### PR TITLE
Feature : Default screen on startup for issue #71

### DIFF
--- a/lib/app/data/db.dart
+++ b/lib/app/data/db.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:isar/isar.dart';
 
 part 'db.g.dart';
@@ -15,6 +16,7 @@ class Settings {
   String? language;
   String firstDay = 'monday';
   String calendarFormat = 'week';
+  String defaultScreen = 'categories';
 }
 
 @collection

--- a/lib/app/data/db.g.dart
+++ b/lib/app/data/db.g.dart
@@ -27,38 +27,43 @@ const SettingsSchema = CollectionSchema(
       name: r'calendarFormat',
       type: IsarType.string,
     ),
-    r'firstDay': PropertySchema(
+    r'defaultScreen': PropertySchema(
       id: 2,
+      name: r'defaultScreen',
+      type: IsarType.string,
+    ),
+    r'firstDay': PropertySchema(
+      id: 3,
       name: r'firstDay',
       type: IsarType.string,
     ),
     r'isImage': PropertySchema(
-      id: 3,
+      id: 4,
       name: r'isImage',
       type: IsarType.bool,
     ),
     r'language': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'language',
       type: IsarType.string,
     ),
     r'materialColor': PropertySchema(
-      id: 5,
+      id: 6,
       name: r'materialColor',
       type: IsarType.bool,
     ),
     r'onboard': PropertySchema(
-      id: 6,
+      id: 7,
       name: r'onboard',
       type: IsarType.bool,
     ),
     r'theme': PropertySchema(
-      id: 7,
+      id: 8,
       name: r'theme',
       type: IsarType.string,
     ),
     r'timeformat': PropertySchema(
-      id: 8,
+      id: 9,
       name: r'timeformat',
       type: IsarType.string,
     )
@@ -84,6 +89,7 @@ int _settingsEstimateSize(
 ) {
   var bytesCount = offsets.last;
   bytesCount += 3 + object.calendarFormat.length * 3;
+  bytesCount += 3 + object.defaultScreen.length * 3;
   bytesCount += 3 + object.firstDay.length * 3;
   {
     final value = object.language;
@@ -109,13 +115,14 @@ void _settingsSerialize(
 ) {
   writer.writeBool(offsets[0], object.amoledTheme);
   writer.writeString(offsets[1], object.calendarFormat);
-  writer.writeString(offsets[2], object.firstDay);
-  writer.writeBool(offsets[3], object.isImage);
-  writer.writeString(offsets[4], object.language);
-  writer.writeBool(offsets[5], object.materialColor);
-  writer.writeBool(offsets[6], object.onboard);
-  writer.writeString(offsets[7], object.theme);
-  writer.writeString(offsets[8], object.timeformat);
+  writer.writeString(offsets[2], object.defaultScreen);
+  writer.writeString(offsets[3], object.firstDay);
+  writer.writeBool(offsets[4], object.isImage);
+  writer.writeString(offsets[5], object.language);
+  writer.writeBool(offsets[6], object.materialColor);
+  writer.writeBool(offsets[7], object.onboard);
+  writer.writeString(offsets[8], object.theme);
+  writer.writeString(offsets[9], object.timeformat);
 }
 
 Settings _settingsDeserialize(
@@ -127,14 +134,15 @@ Settings _settingsDeserialize(
   final object = Settings();
   object.amoledTheme = reader.readBool(offsets[0]);
   object.calendarFormat = reader.readString(offsets[1]);
-  object.firstDay = reader.readString(offsets[2]);
+  object.defaultScreen = reader.readString(offsets[2]);
+  object.firstDay = reader.readString(offsets[3]);
   object.id = id;
-  object.isImage = reader.readBoolOrNull(offsets[3]);
-  object.language = reader.readStringOrNull(offsets[4]);
-  object.materialColor = reader.readBool(offsets[5]);
-  object.onboard = reader.readBool(offsets[6]);
-  object.theme = reader.readStringOrNull(offsets[7]);
-  object.timeformat = reader.readString(offsets[8]);
+  object.isImage = reader.readBoolOrNull(offsets[4]);
+  object.language = reader.readStringOrNull(offsets[5]);
+  object.materialColor = reader.readBool(offsets[6]);
+  object.onboard = reader.readBool(offsets[7]);
+  object.theme = reader.readStringOrNull(offsets[8]);
+  object.timeformat = reader.readString(offsets[9]);
   return object;
 }
 
@@ -152,16 +160,18 @@ P _settingsDeserializeProp<P>(
     case 2:
       return (reader.readString(offset)) as P;
     case 3:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 4:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 5:
-      return (reader.readBool(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 6:
       return (reader.readBool(offset)) as P;
     case 7:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBool(offset)) as P;
     case 8:
+      return (reader.readStringOrNull(offset)) as P;
+    case 9:
       return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -397,6 +407,140 @@ extension SettingsQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'calendarFormat',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> defaultScreenEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'defaultScreen',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+      defaultScreenGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'defaultScreen',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> defaultScreenLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'defaultScreen',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> defaultScreenBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'defaultScreen',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+      defaultScreenStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'defaultScreen',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> defaultScreenEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'defaultScreen',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> defaultScreenContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'defaultScreen',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> defaultScreenMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'defaultScreen',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+      defaultScreenIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'defaultScreen',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+      defaultScreenIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'defaultScreen',
         value: '',
       ));
     });
@@ -1085,6 +1229,18 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
     });
   }
 
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByDefaultScreen() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'defaultScreen', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByDefaultScreenDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'defaultScreen', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy> sortByFirstDay() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'firstDay', Sort.asc);
@@ -1193,6 +1349,18 @@ extension SettingsQuerySortThenBy
   QueryBuilder<Settings, Settings, QAfterSortBy> thenByCalendarFormatDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'calendarFormat', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByDefaultScreen() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'defaultScreen', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByDefaultScreenDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'defaultScreen', Sort.desc);
     });
   }
 
@@ -1309,6 +1477,14 @@ extension SettingsQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Settings, Settings, QDistinct> distinctByDefaultScreen(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'defaultScreen',
+          caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QDistinct> distinctByFirstDay(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -1373,6 +1549,12 @@ extension SettingsQueryProperty
   QueryBuilder<Settings, String, QQueryOperations> calendarFormatProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'calendarFormat');
+    });
+  }
+
+  QueryBuilder<Settings, String, QQueryOperations> defaultScreenProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'defaultScreen');
     });
   }
 

--- a/lib/app/ui/home.dart
+++ b/lib/app/ui/home.dart
@@ -8,6 +8,7 @@ import 'package:zest/app/ui/todos/view/calendar_todos.dart';
 import 'package:zest/app/ui/todos/view/all_todos.dart';
 import 'package:zest/app/ui/todos/widgets/todos_action.dart';
 import 'package:zest/theme/theme_controller.dart';
+import 'package:zest/main.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -40,8 +41,21 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  List<String> getScreens() {
+    return ['categories', 'allTodos', 'calendar'];
+  }
+
+
+  @override
+  void initState() {
+    super.initState();
+    allScreens = getScreens();
+    tabIndex = allScreens.indexOf(allScreens.firstWhere((element) => (element == settings.defaultScreen), orElse: () => allScreens[0]));
+  }
+
   @override
   Widget build(BuildContext context) {
+    allScreens = getScreens();
     return Scaffold(
       body: IndexedStack(index: tabIndex, children: pages),
       bottomNavigationBar: GestureDetector(
@@ -53,17 +67,17 @@ class _HomePageState extends State<HomePage> {
             NavigationDestination(
               icon: const Icon(IconsaxPlusLinear.folder_2),
               selectedIcon: const Icon(IconsaxPlusBold.folder_2),
-              label: 'categories'.tr,
+              label: allScreens[0].tr,
             ),
             NavigationDestination(
               icon: const Icon(IconsaxPlusLinear.task_square),
               selectedIcon: const Icon(IconsaxPlusBold.task_square),
-              label: 'allTodos'.tr,
+              label: allScreens[1].tr,
             ),
             NavigationDestination(
               icon: const Icon(IconsaxPlusLinear.calendar),
               selectedIcon: const Icon(IconsaxPlusBold.calendar),
-              label: 'calendar'.tr,
+              label: allScreens[2].tr,
             ),
             NavigationDestination(
               icon: const Icon(IconsaxPlusLinear.category),

--- a/lib/app/ui/settings/view/settings.dart
+++ b/lib/app/ui/settings/view/settings.dart
@@ -24,6 +24,7 @@ class _SettingsPageState extends State<SettingsPage> {
   final todoController = Get.put(TodoController());
   final isarController = Get.put(IsarController());
   final themeController = Get.put(ThemeController());
+
   String? appVersion;
 
   Future<void> infoVersion() async {
@@ -37,6 +38,12 @@ class _SettingsPageState extends State<SettingsPage> {
     settings.language = '$locale';
     isar.writeTxnSync(() => isar.settings.putSync(settings));
     Get.updateLocale(locale);
+    Get.back();
+  }
+
+  void updateDefaultScreen(String defaultScreen) {
+    settings.defaultScreen = defaultScreen;
+    isar.writeTxnSync(() => isar.settings.putSync(settings));
     Get.back();
   }
 
@@ -396,6 +403,74 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
             SettingCard(
               icon: const Icon(IconsaxPlusLinear.language_square),
+              text: 'defaultScreen'.tr,
+              info: true,
+              infoSettings: true,
+              textInfo: settings.defaultScreen.isNotEmpty ? settings.defaultScreen.tr : allScreens[0].tr,
+              onPressed: () {
+                showModalBottomSheet(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return Padding(
+                      padding: EdgeInsets.only(
+                        bottom: MediaQuery.of(context).padding.bottom,
+                      ),
+                      child: StatefulBuilder(
+                        builder: (BuildContext context, setState) {
+                          return Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                  vertical: 15,
+                                ),
+                                child: Text(
+                                  'defaultScreen'.tr,
+                                  style: context.textTheme.titleLarge?.copyWith(
+                                    fontSize: 20,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                              ListView.builder(
+                                shrinkWrap: true,
+                                physics: const BouncingScrollPhysics(),
+                                itemCount: allScreens.length,
+                                itemBuilder: (context, index) {
+                                  return Card(
+                                    elevation: 4,
+                                    margin: const EdgeInsets.symmetric(
+                                      horizontal: 15,
+                                      vertical: 5,
+                                    ),
+                                    child: ListTile(
+                                      title: Text(
+                                        allScreens[index].tr,
+                                        style: context.textTheme.labelLarge,
+                                        textAlign: TextAlign.center,
+                                      ),
+                                      onTap: () {
+                                        this.setState(() {
+                                          updateDefaultScreen(allScreens[index]);
+                                        });
+                                      },
+                                    ),
+                                  );
+                                },
+                              ),
+                              const Gap(10),
+                            ],
+                          );
+                        },
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+            SettingCard(
+              icon: const Icon(IconsaxPlusLinear.language_square),
               text: 'language'.tr,
               info: true,
               infoSettings: true,
@@ -446,15 +521,17 @@ class _SettingsPageState extends State<SettingsPage> {
                                         style: context.textTheme.labelLarge,
                                         textAlign: TextAlign.center,
                                       ),
-                                      onTap: () {
+                                      onTap: () async {
                                         MyApp.updateAppState(
                                           context,
                                           newLocale:
                                               appLanguages[index]['locale'],
                                         );
+
                                         updateLanguage(
                                           appLanguages[index]['locale'],
                                         );
+                                        this.setState(() {});
                                       },
                                     ),
                                   );

--- a/lib/app/ui/settings/view/settings.dart
+++ b/lib/app/ui/settings/view/settings.dart
@@ -521,7 +521,7 @@ class _SettingsPageState extends State<SettingsPage> {
                                         style: context.textTheme.labelLarge,
                                         textAlign: TextAlign.center,
                                       ),
-                                      onTap: () async {
+                                      onTap: () {
                                         MyApp.updateAppState(
                                           context,
                                           newLocale:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,6 +51,8 @@ final List appLanguages = [
   {'name': 'Português', 'locale': const Locale('pt', 'PT')},
 ];
 
+List<String> allScreens = [];
+
 void main() async {
   final String timeZoneName;
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/translation/ar_ar.dart
+++ b/lib/translation/ar_ar.dart
@@ -79,6 +79,7 @@ class ArAr {
         'amoledTheme': 'سِمة سوداء (AMOLED)',
         'appearance': 'المضهر',
         'functions': 'الدوال',
+        'defaultScreen': 'الشاشة الافتراضية',
         'data': 'بينات',
         'language': 'اللغة',
         'active': 'الشغالة',

--- a/lib/translation/de_de.dart
+++ b/lib/translation/de_de.dart
@@ -81,6 +81,7 @@ class DeDe {
         'amoledTheme': 'AMOLED-theme',
         'appearance': 'Aussehen',
         'functions': 'Funktionen',
+        'defaultScreen': 'Standardbildschirm',
         'data': 'Daten',
         'language': 'Sprache',
         'active': 'Aktiv',

--- a/lib/translation/en_us.dart
+++ b/lib/translation/en_us.dart
@@ -80,6 +80,7 @@ class EnUs {
         'amoledTheme': 'AMOLED-theme',
         'appearance': 'Appearance',
         'functions': 'Functions',
+        'defaultScreen': 'Default Screen',
         'data': 'Data',
         'language': 'Language',
         'active': 'Active',

--- a/lib/translation/es_es.dart
+++ b/lib/translation/es_es.dart
@@ -86,6 +86,7 @@ class EsEs {
         'amoledTheme': 'AMOLED-tema',
         'appearance': 'Apariencia',
         'functions': 'Funciones',
+        'defaultScreen': 'Pantalla predeterminada',
         'data': 'Datos',
         'language': 'Idioma',
         'active': 'Activo',

--- a/lib/translation/fa_ir.dart
+++ b/lib/translation/fa_ir.dart
@@ -83,6 +83,7 @@ class FaIr {
         'amoledTheme': 'تم AMOLED',
         'appearance': 'ظاهر',
         'functions': 'توابع',
+        'defaultScreen': 'صفحه پیش‌فرض',
         'data': 'داده‌ها',
         'language': 'زبان',
         'active': 'فعال',

--- a/lib/translation/fr_fr.dart
+++ b/lib/translation/fr_fr.dart
@@ -85,6 +85,7 @@ class FrFr {
         'amoledTheme': 'AMOLED-thème',
         'appearance': 'Apparence',
         'functions': 'Fonctions',
+        'defaultScreen': 'Écran par défaut',
         'data': 'Données',
         'language': 'Langue',
         'active': 'Active',

--- a/lib/translation/it_it.dart
+++ b/lib/translation/it_it.dart
@@ -81,6 +81,7 @@ class ItIt {
         'amoledTheme': 'Tema AMOLED',
         'appearance': 'Aspetto',
         'functions': 'Funzioni',
+        'defaultScreen': 'Schermo predefinito',
         'data': 'Dati',
         'language': 'Lingua',
         'active': 'Attivo',

--- a/lib/translation/ko_kr.dart
+++ b/lib/translation/ko_kr.dart
@@ -76,6 +76,7 @@ class KoKr {
         'amoledTheme': 'AMOLED 테마',
         'appearance': '디자인',
         'functions': '기능',
+        'defaultScreen': '기본 화면',
         'data': '데이터',
         'language': '언어',
         'active': '수행 중',

--- a/lib/translation/pl_pl.dart
+++ b/lib/translation/pl_pl.dart
@@ -81,6 +81,7 @@ class PlPl {
     'amoledTheme': 'Motyw AMOLED',
     'appearance': 'Wygląd',
     'functions': 'Funkcje',
+    'defaultScreen': 'Ekran domyślny',
     'data': 'Data',
     'language': 'Język',
     'active': 'Aktywne',

--- a/lib/translation/pt_pt.dart
+++ b/lib/translation/pt_pt.dart
@@ -76,6 +76,7 @@ class PtPt {
         'amoledTheme': 'AMOLED-tema',
         'appearance': 'Aparência',
         'functions': 'Características',
+        'defaultScreen': 'Tela padrão',
         'data': 'Dados',
         'language': 'Idioma',
         'active': 'Ativo',

--- a/lib/translation/ru_ru.dart
+++ b/lib/translation/ru_ru.dart
@@ -79,6 +79,7 @@ class RuRu {
         'amoledTheme': 'AMOLED-тема',
         'appearance': 'Внешний вид',
         'functions': 'Функции',
+        'defaultScreen': 'Экран по умолчанию',
         'data': 'Данные',
         'language': 'Язык',
         'active': 'Активные',

--- a/lib/translation/tr_tr.dart
+++ b/lib/translation/tr_tr.dart
@@ -82,6 +82,7 @@ class TrTr {
         'amoledTheme': 'AMOLED-tema',
         'appearance': 'Görünüm',
         'functions': 'Fonksiyonlar',
+        'defaultScreen': 'Varsayılan ekran',
         'data': 'Veri',
         'language': 'Dil',
         'active': 'Aktif',

--- a/lib/translation/vi_vn.dart
+++ b/lib/translation/vi_vn.dart
@@ -80,6 +80,7 @@ class ViVn {
         'amoledTheme': 'Chủ đề AMOLED',
         'appearance': 'Hiển thị',
         'functions': 'Chức năng',
+        'defaultScreen': 'Màn hình mặc định',
         'data': 'Dữ liệu',
         'language': 'Ngôn ngữ',
         'active': 'Hoạt động',

--- a/lib/translation/zh_cn.dart
+++ b/lib/translation/zh_cn.dart
@@ -76,6 +76,7 @@ class ZhCN {
         'amoledTheme': 'AMOLED 主题',
         'appearance': '外观',
         'functions': '功能',
+        'defaultScreen': '默认屏幕',
         'data': '数据',
         'language': '语言',
         'active': '活跃的',

--- a/lib/translation/zh_tw.dart
+++ b/lib/translation/zh_tw.dart
@@ -76,6 +76,7 @@ class ZhTw {
         'amoledTheme': 'AMOLED 主題',
         'appearance': '外觀',
         'functions': '功能',
+        'defaultScreen': '預設畫面',
         'data': '資料',
         'language': '語言',
         'active': '進行中',


### PR DESCRIPTION
1) Added an option in settings to set a default screen that is shown on startup. 

2) Added a new field in the isar database with the 'defaultScreen' parameter. 

3) The tabIndex property in home.dart has been moved to the initState function to set the index to the screeb that user has selected. 

4) The name of the screens are initialized on the build of homepage to update the bottomNavigatioBar items' text in case of a language change.

5) Added localizations from google translate for the settings option 'defaultScreen'.

6) Tested it on multiple devices by updating the latest release with the new branch and also installing the app with the new branch on its own.