### PR TITLE
Fix for issue #18 : Backup not working

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,4 +71,5 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+    implementation 'androidx.documentfile:documentfile:1.0.1'
 }

--- a/android/app/src/main/kotlin/com/yoshi/todark/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yoshi/todark/MainActivity.kt
@@ -1,6 +1,85 @@
 package com.yoshi.todark
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.DocumentsContract
+import androidx.annotation.NonNull
+import androidx.documentfile.provider.DocumentFile
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.FileOutputStream
+import java.io.OutputStream
 
 class MainActivity: FlutterActivity() {
+    private val CHANNEL = "directory_picker"
+    private val REQUEST_CODE = 1001
+    private var result: MethodChannel.Result? = null
+    private var pickedDirectoryUri: Uri? = null
+
+    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "pickDirectory" -> {
+                    this.result = result
+                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                            Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+                    startActivityForResult(intent, REQUEST_CODE)
+                }
+                "writeFile" -> {
+                    val uriString = call.argument<String>("directoryUri")
+                    val fileName = call.argument<String>("fileName")
+                    val fileContent = call.argument<ByteArray>("fileContent")
+
+                    if (uriString != null && fileName != null && fileContent != null) {
+                        val uri = Uri.parse(uriString)
+                        val success = writeFileToDirectory(uri, fileName, fileContent)
+                        result.success(success)
+                    } else {
+                        result.error("INVALID_ARGUMENTS", "Missing required arguments", null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            val uri: Uri? = data?.data
+            if (uri != null) {
+                contentResolver.takePersistableUriPermission(uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                pickedDirectoryUri = uri
+                result?.success(uri.toString()) // Return URI to Flutter
+            } else {
+                result?.success(null)
+            }
+        }
+    }
+
+    private fun writeFileToDirectory(directoryUri: Uri, fileName: String, fileContent: ByteArray): Boolean {
+        val tree = DocumentFile.fromTreeUri(this, directoryUri)
+        if (tree == null || !tree.isDirectory) return false
+
+        val newFile = tree.createFile("application/octet-stream", fileName)
+        if (newFile == null) return false
+
+        try {
+            contentResolver.openOutputStream(newFile.uri)?.use { outputStream ->
+                outputStream.write(fileContent)
+            }
+            return true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return false
+        }
+    }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -22,6 +22,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.11.0"
+  android_intent_plus:
+    dependency: "direct main"
+    description:
+      name: android_intent_plus
+      sha256: dfc1fd3a577205ae8f11e990fb4ece8c90cceabbee56fcf48e463ecf0bd6aae3
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.0"
   ansicolor:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   isar_flutter_libs:
     version: ^3.1.8
     hosted: https://pub.isar-community.dev/
+  android_intent_plus: ^5.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Since android 11+ doesn't allow writing to directories other than Download and Documents, I have written Platform specific code for android to use the SAF. The SAF provides with a uri and also writes the isar backup file to the selected uri in MainActivity.kt.

Since we would need bytes to write using the SAF, I first create a file in the Download directory which is allowed on android devices. Then I get the bytes of this file and create the backup file in the directory user selected, and delete the file from the Download folder. On other platforms, I keep the functionality as it was.

I didn't have an ios device to test features there, but I have tried to keep the ios functionalities from breaking.